### PR TITLE
RIVOS: fix bistro rv64 addressing

### DIFF
--- a/src/ucm/bistro/bistro_rv64.c
+++ b/src/ucm/bistro/bistro_rv64.c
@@ -74,12 +74,12 @@ ucs_status_t ucm_bistro_patch(void *func_ptr, void *hook, const char *symbol,
     uintptr_t hookp = (uintptr_t)hook;
 
     ucm_bistro_patch_t patch = {
-        .rega = LUI  (X31, ((0xFFFFF << 12) & ( ((hookp) >> 32) + 1 ) ) >> 12),
-        .regb = ADDI (X31, X31, ((0xFFF)    & ( ((hookp) >> 32) + 1 ) )      ),
-        .regc = LUI  (X30, ((0xFFFFF << 12) & ( (((hookp)) + 1)     ) ) >> 12),
+        .rega = LUI  (X31, ((0xFFFFF << 12) & (hookp >> 32)) >> 12),
+        .regb = ADDI (X31, X31, (0xFFF      & (hookp >> 32))),
+        .regc = LUI  (X30, ((0xFFFFF << 12) & hookp) >> 12),
         .regd = SLLI (X31, X31, 32),
         .rege = ADD  (X30, X31, X31),
-        .regf = JALR (X31, X0, ((0xFFF)     & ( ((hookp)) + 1)))
+        .regf = JALR (X31, X0, (0xFFF & hookp))
     };
 
     if (orig_func_p != NULL) {


### PR DESCRIPTION
For example, given a hook function pointer: 0x0000_0040_0100_3356

The original code generates the following assembly...

0x00000040010d0080 <+0>:     lui     t6,0x0
0x00000040010d0084 <+4>:     add     t6,t6,65 # 0x41
0x00000040010d0088 <+8>:     lui     t5,0x1003
0x00000040010d008c <+12>:    sll     t6,t6,0x20
0x00000040010d0090 <+16>:    add     t6,t5,t6
0x00000040010d0094 <+20>:    jr      855(t6)

...and calculates an address of 0x4101003355.